### PR TITLE
Update to latest message broker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
+docker-compose*
 .dockerignore
 /node_modules/
 /.next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build
 
 # DSB Container
-FROM 098061033856.dkr.ecr.us-east-1.amazonaws.com/ew-dos-dsb-ecr:7147f01c-6785-4927-a5fa-a591ce6ca4ee
+FROM 098061033856.dkr.ecr.us-east-1.amazonaws.com/ew-dos-dsb-ecr:3598aac0-11b3-420e-a06b-892baaacd7a6
 
 RUN mkdir -p /var/deployment/apps/dsb-client-gateway
 

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+    message-broker:
+      image: 098061033856.dkr.ecr.us-east-1.amazonaws.com/ew-dos-dsb-ecr:3598aac0-11b3-420e-a06b-892baaacd7a6
+      environment:
+        - PORT=3001
+        - MB_DID=did:ethr:0x4eD992B299f15eaD372E19DDAB2f95704F69D1B7
+        - PRIVATE_KEY=0x473fe7abcf5a91e6e0d8865998780bdce380f042587d92570db674e9d2d67b4e
+        - JWT_SECRET=secret
+        #TODO: run NATS locally
+        - NATS_JS_URL=nats://20.83.92.252:4222
+        - WEB3_URL=https://volta-internal-archive.energyweb.org
+      ports:
+        - 3001:3001


### PR DESCRIPTION
Using the latest `release` branch, there are no breaking changes that we need to update for.

I have changed the base image used in the container to the latest specific `release` tag and also provided a docker-compose file for spinning up the base image dependency to test against locally (i.e. with `yarn dev`).

There will be changes we need to incorporate in the next message broker release (e.g. correlation id).