### PR TITLE
Translate correlation ID to transaction ID

### DIFF
--- a/public/rest.yaml
+++ b/public/rest.yaml
@@ -116,7 +116,7 @@ paths:
       tags:
         - Message
       summary: Send message on a DSB channel
-      description: Note that resending a message with the same `correlationId` will
+      description: Note that resending a message with the same `transactionId` will
         return a 200 status code. The ID received will be the same as the first message
         sent. A consumer will only see a single message.
 
@@ -489,7 +489,7 @@ components:
           description: Message data conforming to channel
           example: '{"some": "data"}'
           type: string
-        correlationId:
+        transactionId:
           description: Idempotency (message deduplication) identifier, e.g. UUID (v4)
           example: 'e7dd9967-c369-4609-99ab-bdbb7d6a5ee6'
           type: string
@@ -556,7 +556,7 @@ components:
           description: Timestamp the message was sent in nanoseconds
           example: 1631179721295000000
           type: number
-        correlationId:
+        transactionId:
           description: Idempotency (message deduplication) identifier, e.g. UUID (v4)
           example: 'e7dd9967-c369-4609-99ab-bdbb7d6a5ee6'
           type: string

--- a/public/ws.yaml
+++ b/public/ws.yaml
@@ -45,7 +45,7 @@ components:
             type: string
             description: Payload of the message on the channel
             example: "{\"data\":\"test\"}"
-          correlationId:
+          transactionId:
             type: string
             description: User-defined unique identifier for tracing the message
             example: e9c82d33-d60c-42d8-bc76-e5107d97e1b9
@@ -89,7 +89,7 @@ components:
             description: Timestamp the message was sent in nanoseconds
             example: 1631179721295000000
             type: number
-          correlationId:
+          transactionId:
             description: Idempotency key for message depuplication (e.g. UUID v4)
             example: e9c82d33-d60c-42d8-bc76-e5107d97e1b9
             type: string
@@ -97,7 +97,7 @@ components:
       payload:
         type: object
         properties:
-          correlationId:
+          transactionId:
             type: string
             description: The user-defined unique identifier present in the
               attempted publishing of a message
@@ -124,7 +124,3 @@ components:
                     missingProperty: id
                   message: must have required property 'id'
                 description: Any additional information attributed to the error
-
-
-
-          

--- a/src/components/UploadFile/UploadContainer.tsx
+++ b/src/components/UploadFile/UploadContainer.tsx
@@ -23,8 +23,8 @@ export const UploadContainer = ({ auth, channels }: UploadContainerProps) => {
         formData,
         auth ? { headers: { Authorization: `Bearer ${auth}`, 'content-type': 'multipart/form-data' } } : undefined
       )
-      const { id, correlationId } = res.data
-      swal(`Success: ${id}`, `File uploaded with correlation ID\n${correlationId}`, 'success')
+      const { id, transactionId } = res.data
+      swal(`Success: ${id}`, `File uploaded with transaction ID\n${transactionId}`, 'success')
     } catch (err) {
       if (axios.isAxiosError(err)) {
         swal('Error', err.response?.data?.err?.reason, 'error')

--- a/src/pages/api/v1/upload/index.ts
+++ b/src/pages/api/v1/upload/index.ts
@@ -6,7 +6,7 @@ import { isAuthorized } from '../../../../services/auth.service'
 import { DsbApiService } from '../../../../services/dsb-api.service'
 import { signPayload } from '../../../../services/identity.service'
 
-type Response = (SendMessageResult & { correlationId: string }) | { err: ErrorBody }
+type Response = (SendMessageResult & { transactionId: string }) | { err: ErrorBody }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Response>) {
   if (req.method !== 'POST') {
@@ -47,18 +47,18 @@ async function forPOST(req: NextApiRequest, res: NextApiResponse<Response>): Pro
       payload: payload
     }
 
-    const correlationId = uuidv4()
+    const transactionId = uuidv4()
 
     const { ok: sent, err: sendError } = await DsbApiService.init().sendMessage({
       ...body,
-      correlationId,
+      transactionId,
       signature
     })
 
     if (!sent) {
       throw sendError
     }
-    return res.status(200).send({ ...sent, correlationId })
+    return res.status(200).send({ ...sent, transactionId })
   } catch (err) {
     if (err instanceof GatewayError) {
       res.status(err.statusCode ?? 500).send({ err: err.body })

--- a/src/services/websocket.service.test.ts
+++ b/src/services/websocket.service.test.ts
@@ -112,11 +112,11 @@ describe('WebSocketService', () => {
         const payload = {
           fqcn: 'test.channel',
           payload: '<payload>',
-          correlationId: '123'
+          transactionId: '123'
         }
         conn.on('message', (data) => {
-          const msg: { correlationId: string; err: string } = parseMessage(data)
-          expect(msg.correlationId).toBe(payload.correlationId)
+          const msg: { transactionId: string; err: string } = parseMessage(data)
+          expect(msg.transactionId).toBe(payload.transactionId)
           expect(msg.err).toBeDefined()
           conn.close()
           done()
@@ -167,8 +167,8 @@ describe('WebSocketService', () => {
           const msg: any = parseMessage(data)
           if (msg.fqcn) {
             events.emit(`${msg.fqcn}#${msg.id}`, msg)
-          } else if (msg.correlationId) {
-            events.emit(msg.correlationId, msg)
+          } else if (msg.transactionId) {
+            events.emit(msg.transactionId, msg)
           }
         })
       })
@@ -222,7 +222,8 @@ describe('WebSocketService', () => {
           payload: '<payload>',
           sender: 'did:ethr:<address>',
           signature: 'signed',
-          timestampNanos: 0
+          timestampNanos: 0,
+          transactionId: '<key>',
         }
         events.on(`${payload.fqcn}#${payload.id}`, (msg) => {
           expect(msg).toEqual(payload)
@@ -241,10 +242,10 @@ describe('WebSocketService', () => {
         const payload = {
           fqcn: 'my.channel',
           payload: '<test_payload>',
-          correlationId: '456'
+          transactionId: '456'
         }
-        events.on(payload.correlationId, (msg) => {
-          expect(msg.correlationId).toBe(payload.correlationId)
+        events.on(payload.transactionId, (msg) => {
+          expect(msg.transactionId).toBe(payload.transactionId)
           expect(msg.err).toBeDefined()
           client.close()
           done()

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -89,7 +89,7 @@ export class WebSocketServer {
         if (!ok) {
           connection.send(
             JSON.stringify({
-              correlationId: message.correlationId,
+              transactionId: message.transactionId,
               err: err?.body
             })
           )
@@ -185,18 +185,18 @@ export class WebSocketClient {
           throw sendError
         }
       } catch (err) {
-        if (message.correlationId) {
+        if (message.transactionId) {
           if (err instanceof GatewayError) {
             this.connection.send(
               JSON.stringify({
-                correlationId: message.correlationId,
+                transactionId: message.transactionId,
                 err: err.body
               })
             )
           } else {
             this.connection.send(
               JSON.stringify({
-                correlationId: message.correlationId,
+                transactionId: message.transactionId,
                 err: err instanceof Error ? err.message : err
               })
             )

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -38,7 +38,7 @@ export type SendMessageData = {
   fqcn: string
   topic: string
   payload: string
-  correlationId?: string
+  transactionId?: string
   signature: string
 }
 
@@ -60,6 +60,7 @@ export type Message = {
   sender: string
   signature: string
   timestampNanos: number
+  transactionId?: string
 }
 
 export type Channel = {


### PR DESCRIPTION
Use transaction ID on the gateway side, translate correlation ID used by  message broker. 