### PR TITLE
add security scanning to actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,24 @@ jobs:
       run: |
         echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" > .env.local
 
+    - name: Build docker image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        BUILD_ID: ${{needs.unique_id.outputs.unique_id}}
+      run: |
+        docker build -t dsb-client-gateway .
+        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
+        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:canary
+
+    - name: Scan local docker image
+      uses: anchore/scan-action@v3
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      with:
+        image: $ECR_REGISTRY/dsb-message-broker:canary
+        fail-build: true
+        severity-cutoff: critical
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -48,15 +66,12 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build docker image and push (AWS)
+    - name: Push docker image to AWS
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         BUILD_ID: ${{needs.unique_id.outputs.unique_id}}
       run: |
-        docker build -t dsb-client-gateway .
-        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
         docker push $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
-        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:canary
         docker push $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:canary
 
     - name: Logout of Amazon ECR

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,3 +47,9 @@ jobs:
 
     - name: Run tests
       run: yarn test
+
+    - name: Scan project
+      uses: anchore/scan-action@v3
+      with:
+        path: "."
+        severity-cutoff: critical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,24 @@ jobs:
       run: |
         echo "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN" > .env.local
 
+    - name: Build docker image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        BUILD_ID: ${{needs.semantic-version.outputs.version_tag}}
+      run: |
+        docker build -t dsb-client-gateway .
+        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
+        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:latest
+
+    - name: Scan local docker image
+      uses: anchore/scan-action@v3
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      with:
+        image: $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:latest"
+        fail-build: true
+        severity-cutoff: critical
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -70,16 +88,12 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build & push docker image to ECR
+    - name: Push docker image to ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         BUILD_ID: ${{needs.semantic-version.outputs.version_tag}}
-        SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
       run: |
-        docker build -t dsb-client-gateway .
-        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
         docker push $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:$BUILD_ID
-        docker tag dsb-client-gateway $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:latest
         docker push $ECR_REGISTRY/ew-dos-dsb-gateway-ecr:latest
 
     - name: Logout of Amazon ECR


### PR DESCRIPTION
scan after build and before push; fail if critical dependencies exist