### PR TITLE
fix: replace total with count

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/topic/dto/index.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/topic/dto/index.ts
@@ -411,7 +411,7 @@ export class PaginatedResponse {
     type: Number,
     example: 1,
   })
-  public total: number;
+  public count: number;
 
   @ApiProperty({
     description: 'limit of channels',
@@ -444,7 +444,7 @@ export class PaginatedSearchTopicResponse {
     type: Number,
     example: 1,
   })
-  public total: number;
+  public count: number;
 
   @ApiProperty({
     description: 'limit of channels',


### PR DESCRIPTION
Changing the `total` key in `paginatedResponse` and `paginatedSearchTopicResponse` to `count`to update swagger with the correct naming for generating the python client.